### PR TITLE
Allow custom `app_name` when creating artifact

### DIFF
--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -132,7 +132,7 @@ module Jara
 
     def find_local_artifact
       candidates = Dir[File.join(project_dir, 'build', @environment, "*.#{@archiver.extension}")]
-      candidates.select! { |path| path.include?(branch_sha[0, 8]) }
+      candidates.select! { |path| path.match(/#{app_name}-\w+-\d{14}-#{branch_sha[0, 8]}/) }
       candidates.sort.last
     end
 

--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -18,6 +18,7 @@ module Jara
       @re_release = options.fetch(:re_release, false)
       @extra_metadata = options[:metadata] || {}
       @build_command = options[:build_command]
+      @app_name = options[:app_name]
       @shell = options[:shell] || Shell.new
       @archiver = create_archiver(options[:archiver])
       @file_system = options[:file_system] || FileUtils
@@ -84,7 +85,7 @@ module Jara
     end
 
     def app_name
-      File.basename(project_dir)
+      @app_name || File.basename(project_dir)
     end
 
     def project_dir

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -259,7 +259,7 @@ module Jara
         end
       end
 
-      context 'when an artifact for the current SHA already exists' do
+      context 'when an artifact for the current SHA and app name already exists' do
         before do
           FileUtils.mkdir_p('build/production')
           FileUtils.touch("build/production/fake_app-production-20140409163201-#{master_sha[0, 8]}.bar")
@@ -273,6 +273,18 @@ module Jara
         it 'logs a message saying that no new artifact was built, with the name of the existing' do
           production_releaser.build_artifact
           logger.should have_received(:warn).with(/an artifact for #{master_sha[0, 8]} already exists: fake_app-production-\d{14}-[a-f0-9]{8}\.bar/i)
+        end
+      end
+
+      context 'when an artifact for the current SHA but for a different app name already exists' do
+        before do
+          FileUtils.mkdir_p('build/production')
+          FileUtils.touch("build/production/fake_app-other-production-20140409163201-#{master_sha[0, 8]}.bar")
+        end
+
+        it 'builds a new artifact' do
+          production_releaser.build_artifact
+          archiver.should have_received(:create)
         end
       end
 

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -171,6 +171,14 @@ module Jara
         components[3].should == master_sha[0, 8]
       end
 
+      it 'uses the specified app name instead of the project directory name' do
+        options[:app_name] = 'test_app'
+        production_releaser.build_artifact
+        file_name = archive_options.last[:archive_name]
+        components = file_name.split('.').first.split('-')
+        components.first.should == 'test_app'
+      end
+
       it 'lets the archiver choose the file extension' do
         production_releaser.build_artifact
         file_name = archive_options.last[:archive_name]


### PR DESCRIPTION
Currently it’s only possible to build an artifact that uses the same name as the basename of the project, so it’s essentially impossible to build more than one artifact per Git repository.

This commit adds an `:app_name` option that will only change the `app_name` part of the artifact name. It could be debated whether this option should be passed down to the #create method of the archiver as
well, but for simplicity it’s currently not.