### PR TITLE
Releaser can now build from another branch than environment

### DIFF
--- a/lib/jara/cli.rb
+++ b/lib/jara/cli.rb
@@ -15,6 +15,7 @@ module Jara
       options = {}
       options[:archiver] = @archiver if @archiver
       options[:build_command] = @build_command if @build_command
+      options[:branch] = @branch if @branch
       releaser = Jara::Releaser.new(@environment, @bucket, options)
       case @command
       when /help|-h/
@@ -44,6 +45,7 @@ module Jara
         parser.separator 'Common options:'
         parser.on('-e', '--environment=ENV', 'Environment to release to (e.g. production, staging)') { |e| @environment = e }
         parser.on('-a', '--archiver=TYPE', 'Archiver to use (jar or tgz)') { |t| @archiver = t.to_sym }
+        parser.on('--branch=BRANCH', 'Branch to release from, if not same as environment (production must be released from master)') { |b| @branch = b }
         parser.on('-c', '--build-command=COMMAND', 'Command to run before creating the artifact') { |c| @build_command = c }
         parser.on('-h', '--help', 'Show this message') { @command = 'help' }
         parser.separator ''

--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -25,12 +25,13 @@ module Jara
       @file_system = options[:file_system] || FileUtils
       @s3 = options[:s3]
       @logger = options[:logger] || IoLogger.new($stderr)
-      @branch = if options[:branch]
-        options[:branch]
-      elsif @environment == 'production'
-        'master'
+      if @environment == 'production'
+        if options[:branch]
+          raise JaraError, 'Production must be released from master'
+        end
+        @branch = 'master'
       else
-        @environment
+        @branch = options[:branch] || @environment
       end
     end
 

--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -25,7 +25,13 @@ module Jara
       @file_system = options[:file_system] || FileUtils
       @s3 = options[:s3]
       @logger = options[:logger] || IoLogger.new($stderr)
-      @branch = @environment == 'production' ? 'master' : @environment
+      @branch = if options[:branch]
+        options[:branch]
+      elsif @environment == 'production'
+        'master'
+      else
+        @environment
+      end
     end
 
     def build_artifact

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -115,6 +115,10 @@ module Jara
         '13525a13d4d2d07fd4bdd18c1fce722bc8f435b8'
       end
 
+      let :another_branch_sha do
+        '4e9fd31a582eef0f071a3989dc892e5d8eb2b748'
+      end
+
       let :exec_handler do
         lambda do |command|
           case command
@@ -122,6 +126,8 @@ module Jara
             "#{master_sha}\n#{master_sha}\n"
           when 'git rev-parse staging && git rev-parse origin/staging'
             "#{staging_sha}\n#{staging_sha}\n"
+          when 'git rev-parse another_branch && git rev-parse origin/another_branch'
+            "#{another_branch_sha}\n#{another_branch_sha}\n"
           when /^git archive .+ [a-f0-9]{40}/
             nil
           else
@@ -153,6 +159,13 @@ module Jara
         executed_commands.clear
         staging_releaser.build_artifact
         command = executed_commands.grep(/^git archive .+ #{staging_sha}/).first
+        command.should_not be_empty
+      end
+
+      it 'allows branch to be specified in options' do
+        options[:branch] = 'another_branch'
+        production_releaser.build_artifact
+        command = executed_commands.grep(/^git archive .+ #{another_branch_sha}/).first
         command.should_not be_empty
       end
 

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -164,9 +164,14 @@ module Jara
 
       it 'allows branch to be specified in options' do
         options[:branch] = 'another_branch'
-        production_releaser.build_artifact
+        staging_releaser.build_artifact
         command = executed_commands.grep(/^git archive .+ #{another_branch_sha}/).first
         command.should_not be_empty
+      end
+
+      it 'does not allow branch to be specified for production environment' do
+        options[:branch] = 'another_branch'
+        expect { production_releaser.build_artifact }.to raise_error(JaraError, /must be released from master/i)
       end
 
       it 'logs the SHA and branch it checked out' do


### PR DESCRIPTION
Sometimes you want to release an artifact from a different branch than the environment name, this adds a branch option to allow for that.