### PR TITLE
Added additional git metadata

### DIFF
--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -133,9 +133,17 @@ module Jara
         'sha' => branch_sha,
         'remote' => git_remote,
       }
+      m.merge!(git_metadata)
       m.merge!(@extra_metadata)
       m.merge!(@archiver.metadata)
       m
+    end
+
+    def git_metadata
+      {
+        'git_sha' => branch_sha,
+        'git_remote' => git_remote,
+      }
     end
 
     def find_local_artifact

--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -127,6 +127,18 @@ module Jara
       @git_remote ||= @shell.exec('git config --get remote.origin.url')
     end
 
+    def git_author_name
+      @git_author_name ||= @shell.exec('git show %s -s --format=format:"%%aN"' % [@branch_sha])
+    end
+
+    def git_author_email
+      @git_author_email ||= @shell.exec('git show %s -s --format=format:"%%aE"' % [@branch_sha])
+    end
+
+    def git_title
+      @git_title ||= @shell.exec('git show %s -s --format=format:"%%s"' % [@branch_sha])
+    end
+
     def metadata
       m = {
         'packaged_by' => "#{ENV['USER']}@#{Socket.gethostname}",
@@ -143,6 +155,9 @@ module Jara
       {
         'git_sha' => branch_sha,
         'git_remote' => git_remote,
+        'git_author_name' => git_author_name,
+        'git_author_email' => git_author_email,
+        'git_title' => git_title,
       }
     end
 

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -497,6 +497,14 @@ module Jara
         )
       end
 
+      it 'sets Git metadata with the full SHA, the Git remote, author and title' do
+        production_releaser.release
+        s3_puts.last[:metadata].should include(
+          'git_sha' => sha,
+          'git_remote' => 'git@example.com:foo/bar',
+        )
+      end
+
       it 'sets metadata from the archiver' do
         production_releaser.release
         s3_puts.last[:metadata].should include('foo' => 'bar')

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -431,6 +431,12 @@ module Jara
             nil
           when 'git config --get remote.origin.url'
             'git@example.com:foo/bar'
+          when "git show #{sha} -s --format=format:\"%aN\""
+            'Some Author'
+          when "git show #{sha} -s --format=format:\"%aE\""
+            'email@example.com'
+          when "git show #{sha} -s --format=format:\"%s\""
+            'This is a commit doing something'
           else
             raise 'Unsupported command: `%s`' % command
           end
@@ -502,6 +508,9 @@ module Jara
         s3_puts.last[:metadata].should include(
           'git_sha' => sha,
           'git_remote' => 'git@example.com:foo/bar',
+          'git_author_name' => 'Some Author',
+          'git_author_email' => 'email@example.com',
+          'git_title' => 'This is a commit doing something',
         )
       end
 

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -489,29 +489,31 @@ module Jara
         s3_puts.last[:content_md5].should == '07BzhNET7exJ6qYjitX/AA=='
       end
 
-      it 'sets metadata that includes who built the artifact' do
-        production_releaser.release
-        s3_puts.last[:metadata]['packaged_by'].should include(%x(whoami).strip)
-        s3_puts.last[:metadata]['packaged_by'].should match(/^.+@.+$/)
-      end
+      context 'sets metadata that' do
+        it 'includes who built the artifact' do
+          production_releaser.release
+          s3_puts.last[:metadata]['packaged_by'].should include(%x(whoami).strip)
+          s3_puts.last[:metadata]['packaged_by'].should match(/^.+@.+$/)
+        end
 
-      it 'sets legacy metadata with the full SHA and the Git remote' do
-        production_releaser.release
-        s3_puts.last[:metadata].should include(
-          'sha' => sha,
-          'remote' => 'git@example.com:foo/bar',
-        )
-      end
+        it 'includes legacy details like SHA and Git remote' do
+          production_releaser.release
+          s3_puts.last[:metadata].should include(
+            'sha' => sha,
+            'remote' => 'git@example.com:foo/bar',
+          )
+        end
 
-      it 'sets Git metadata with the full SHA, the Git remote, author and title' do
-        production_releaser.release
-        s3_puts.last[:metadata].should include(
-          'git_sha' => sha,
-          'git_remote' => 'git@example.com:foo/bar',
-          'git_author_name' => 'Some Author',
-          'git_author_email' => 'email@example.com',
-          'git_title' => 'This is a commit doing something',
-        )
+        it 'includes Git details like the full SHA, remote, commit author and title' do
+          production_releaser.release
+          s3_puts.last[:metadata].should include(
+            'git_sha' => sha,
+            'git_remote' => 'git@example.com:foo/bar',
+            'git_author_name' => 'Some Author',
+            'git_author_email' => 'email@example.com',
+            'git_title' => 'This is a commit doing something',
+          )
+        end
       end
 
       it 'sets metadata from the archiver' do

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -483,10 +483,14 @@ module Jara
         s3_puts.last[:content_md5].should == '07BzhNET7exJ6qYjitX/AA=='
       end
 
-      it 'sets metadata that includes who built the artifact, the full SHA, the Git remote' do
+      it 'sets metadata that includes who built the artifact' do
         production_releaser.release
         s3_puts.last[:metadata]['packaged_by'].should include(%x(whoami).strip)
         s3_puts.last[:metadata]['packaged_by'].should match(/^.+@.+$/)
+      end
+
+      it 'sets legacy metadata with the full SHA and the Git remote' do
+        production_releaser.release
         s3_puts.last[:metadata].should include(
           'sha' => sha,
           'remote' => 'git@example.com:foo/bar',


### PR DESCRIPTION
This pull request aims to increase the usefulness of the S3 metadata for the released artifacts. As a start, it adds author, email and commit message for the last commit, which would enable notifications when a release is deployed.

The `sha` and `remote` properties are from this point deprecated, and will be removed in the next major release. They should be replaced with `git_sha` and `git_remote`, to make the source of the artifact more obvious.