### PR TITLE
Recode S3 metadata using ASCII \u{CODEPOINT} sequences

### DIFF
--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -161,6 +161,18 @@ module Jara
       }
     end
 
+    def ascii_metadata
+      m = {}
+      metadata.each do |key, value|
+        m[ascii(key)] = ascii(value)
+      end
+      m
+    end
+
+    def ascii(str)
+      str.to_s.encode(Encoding::ASCII, fallback: proc { |chr| sprintf('\u{%x}', chr.ord) })
+    end
+
     def find_local_artifact
       candidates = Dir[File.join(project_dir, 'build', @environment, "*.#{@archiver.extension}")]
       candidates.select! { |path| path.match(/#{app_name}-\w+-\d{14}-#{branch_sha[0, 8]}/) }
@@ -176,7 +188,7 @@ module Jara
           key: remote_path,
           content_type: @archiver.content_type,
           content_md5: content_md5,
-          metadata: metadata,
+          metadata: ascii_metadata,
           body: io,
         )
       end

--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -124,19 +124,19 @@ module Jara
     end
 
     def git_remote
-      @git_remote ||= @shell.exec('git config --get remote.origin.url')
+      @git_remote ||= @shell.exec('git config --get remote.origin.url').chomp
     end
 
     def git_author_name
-      @git_author_name ||= @shell.exec('git show %s -s --format=format:"%%aN"' % [@branch_sha])
+      @git_author_name ||= @shell.exec('git show %s -s --format=format:"%%aN"' % [@branch_sha]).chomp
     end
 
     def git_author_email
-      @git_author_email ||= @shell.exec('git show %s -s --format=format:"%%aE"' % [@branch_sha])
+      @git_author_email ||= @shell.exec('git show %s -s --format=format:"%%aE"' % [@branch_sha]).chomp
     end
 
     def git_title
-      @git_title ||= @shell.exec('git show %s -s --format=format:"%%s"' % [@branch_sha])
+      @git_title ||= @shell.exec('git show %s -s --format=format:"%%s"' % [@branch_sha]).chomp
     end
 
     def metadata

--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -170,7 +170,7 @@ module Jara
     end
 
     def ascii(str)
-      str.to_s.encode(Encoding::ASCII, fallback: proc { |chr| sprintf('\u{%x}', chr.ord) })
+      str.to_s.gsub(/[^\u{20}-\u{7e}]/) { |chr| sprintf('\u{%x}', chr.ord) }
     end
 
     def find_local_artifact

--- a/spec/jara/releaser_spec.rb
+++ b/spec/jara/releaser_spec.rb
@@ -533,6 +533,12 @@ module Jara
         s3_puts.last[:metadata].should include('sha' => 'bar', 'packaged_by' => 'me')
       end
 
+      it 'recodes metadata in plain ASCII to work around aws-sdk-core limitations' do
+        options[:metadata] = {'π' => 'µ'}
+        production_releaser.release
+        s3_puts.last[:metadata].should include('\u{3c0}' => '\u{b5}')
+      end
+
       it 'logs that the artifact was uploaded' do
         production_releaser.release
         logger.should have_received(:info).with(%r<artifact uploaded to s3://artifact-bucket/production/fake_app/fake_app-production-\d{14}-[a-f0-9]{8}\.bar>i)


### PR DESCRIPTION
The motivation for doing this is to ensure that people with non-ASCII names in their Git configuration is able to release artifacts to S3.

With the current state of affairs, the release fails with a rather cryptic `Aws::S3::Errors::SignatureDoesNotMatch`. This turns out to be because AWS changes any non-ASCII bytes to a literal question mark `?`, when creating the canonical request. The documentation says nothing about this, so perhaps it should not come as a surprise that Amazon's own tooling doesn't do this.

By fixing the signature calculation, putting UTF-8 data to S3 actually works, but when retrieving the data it is returned in MIME Encoded-Word format, which is typically not handled by HTTP clients (awscli being an important example).

The proposed encoding is a bit easier on the eyes than the MIME option, for clients with no support for encoded headers, and where the value is mostly ASCII.
