### PR TITLE
Jara should work with either aws-sdk v2 and v3

### DIFF
--- a/lib/jara/releaser.rb
+++ b/lib/jara/releaser.rb
@@ -4,9 +4,12 @@ require 'tmpdir'
 require 'fileutils'
 require 'pathname'
 require 'digest/md5'
-require 'aws-sdk-core'
 require 'socket'
-
+begin
+  require 'aws-sdk-s3'
+rescue LoadError
+  require 'aws-sdk-core'
+end
 
 module Jara
   ExecError = Class.new(JaraError)


### PR DESCRIPTION
In aws-sdk v3, aws-sdk-core still exists, but has only core libraries. To get S3 support you need to explicitly require aws-sdk-s3. In order to support users with both v2 and v3 dependencies, try first to require v3 aws-sdk-s3, then fall back to require v2 aws-sdk-core. Both have identical API, so this should be compatible.