### PR TITLE
Fix jar packaging spec failure introduced by Puck 1.2.4

### DIFF
--- a/spec/integration/jara_spec.rb
+++ b/spec/integration/jara_spec.rb
@@ -104,7 +104,7 @@ describe 'Jara' do
         end
 
         it 'includes the dependencies' do
-          jar_entries.grep(%r{META-INF/gem.home/paint-[^/]+/lib/paint.rb}).should_not be_empty
+          jar_entries.grep(%r{META-INF/gem.home/.+/paint.rb}).should_not be_empty
         end
 
         it 'does not include dependencies from groups other than the default' do


### PR DESCRIPTION
In https://github.com/iconara/puck/releases/tag/v1.2.4 changed puck's behavior to move gems into `gem.home/gems/` which broke a jar packaging test. This fix makes it more permissive, since the spec should not really care about exact dir structure.